### PR TITLE
Use * rather than % for wildcard.

### DIFF
--- a/bionomia_gbif_request.json
+++ b/bionomia_gbif_request.json
@@ -32,19 +32,19 @@
             {
               "type": "like",
               "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "%BOLD:%",
+              "value": "*BOLD:*",
               "matchCase": "true"
             },
             {
               "type": "like",
               "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "%BOLD-%",
+              "value": "*BOLD-*",
               "matchCase": "true"
             },
             {
               "type": "like",
               "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "%BIOUG%",
+              "value": "*BIOUG*",
               "matchCase": "true"
             }
           ]


### PR DESCRIPTION
Due to a change in the GBIF API – we had different behaviour depending on how the download was produced.