### PR TITLE
Allow a null verbatim scientific name.

### DIFF
--- a/bionomia_gbif_request.json
+++ b/bionomia_gbif_request.json
@@ -25,30 +25,42 @@
         ]
       },
       {
-        "type": "not",
-        "predicate": {
-          "type": "or",
-          "predicates": [
-            {
-              "type": "like",
-              "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "*BOLD:*",
-              "matchCase": "true"
-            },
-            {
-              "type": "like",
-              "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "*BOLD-*",
-              "matchCase": "true"
-            },
-            {
-              "type": "like",
-              "key": "VERBATIM_SCIENTIFIC_NAME",
-              "value": "*BIOUG*",
-              "matchCase": "true"
+        "type": "or",
+        "predicates": [
+          {
+            "type": "not",
+            "predicate": {
+              "type": "isNotNull",
+              "parameter": "VERBATIM_SCIENTIFIC_NAME"
             }
-          ]
-        }
+          },
+          {
+            "type": "not",
+            "predicate": {
+              "type": "or",
+              "predicates": [
+                {
+                  "type": "like",
+                  "key": "VERBATIM_SCIENTIFIC_NAME",
+                  "value": "*BOLD:*",
+                  "matchCase": "true"
+                },
+                {
+                  "type": "like",
+                  "key": "VERBATIM_SCIENTIFIC_NAME",
+                  "value": "*BOLD-*",
+                  "matchCase": "true"
+                },
+                {
+                  "type": "like",
+                  "key": "VERBATIM_SCIENTIFIC_NAME",
+                  "value": "*BIOUG*",
+                  "matchCase": "true"
+                }
+              ]
+            }
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
I think this solves part of https://github.com/gbif/portal-feedback/issues/3640, although my test download hasn't finished yet.

The current download predicate requires a non-null verbatim scientific name. There's an explanation in https://github.com/gbif/occurrence/issues/251#issuecomment-845445870, but I think we forgot to do anything about it due to the Field Museum fixing the other issue on their side.